### PR TITLE
allow disable machine

### DIFF
--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -18,12 +18,12 @@ module EnumMachine
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition
           after_validation do
             unless (attr_changes = changes['#{attr}']).blank?
-              @@#{attr}_machine.fetch_before_transitions(attr_changes).each { |i| i.call(self) }
+              @@#{attr}_machine.fetch_before_transitions(attr_changes).each { |i| i.call(self, *attr_changes) }
             end
           end
           after_save do
             unless (attr_changes = previous_changes['#{attr}']).blank?
-              @@#{attr}_machine.fetch_after_transitions(attr_changes).each { |i| i.call(self) }
+              @@#{attr}_machine.fetch_after_transitions(attr_changes).each { |i| i.call(self, *attr_changes) }
             end
           end
         RUBY

--- a/lib/enum_machine/machine.rb
+++ b/lib/enum_machine/machine.rb
@@ -14,6 +14,14 @@ module EnumMachine
     end
 
     # public api
+    def disable(&block)
+      @disabled = true
+      block.call
+    ensure
+      @disabled = false
+    end
+
+    # public api
     # transitions('s1' => 's2', %w[s3 s3] => 's4')
     def transitions(from__to_hash)
       validate_state!(from__to_hash)
@@ -66,11 +74,15 @@ module EnumMachine
     # internal api
     def fetch_before_transitions(from__to)
       validate_transition!(from__to)
+      return [] if @disabled
+
       @before_transition.fetch(from__to, [])
     end
 
     # internal api
     def fetch_after_transitions(from__to)
+      return [] if @disabled
+
       @after_transition.fetch(from__to, [])
     end
 

--- a/lib/enum_machine/machine.rb
+++ b/lib/enum_machine/machine.rb
@@ -14,9 +14,9 @@ module EnumMachine
     end
 
     # public api
-    def disable(&block)
+    def disable(&_block)
       @disabled = true
-      block.call
+      yield
     ensure
       @disabled = false
     end


### PR DESCRIPTION
На практике мне это потребовалось для создания фикстуры в тестах. На создание закупки (переход state `nil => 'created'`) навешен коллбек, который отправляет заявку в ТК. В тесте, который проверяет именно эту отправку, получается уродливое решение:

```
RSpec.describe SupplierDelivery::Services::CreateApiDelivery do
  let(:purchase) do
    allow(described_class).to receive(:call)
    c = create(:purchase, supplier: supplier)
    RSpec::Mocks.space.proxy_for(described_class).reset
    c
  end
```

Но были и другие места, где пришлось делать update_column, чтобы не вызывать коллбек