### PR TITLE
changed context in transition callbacks

### DIFF
--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -19,13 +19,13 @@ module EnumMachine
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition
           after_validation do
             if (attr_changes = changes['#{attr}']) #{skip_cond}
-              @@#{attr}_machine.fetch_before_transitions(attr_changes).each { |i| i.call(self) }
+              @@#{attr}_machine.fetch_before_transitions(attr_changes).each { |block| instance_exec(self, *attr_changes, &block) }
             end
           end
 
           after_save do
             if (attr_changes = previous_changes['#{attr}']) #{skip_cond}
-              @@#{attr}_machine.fetch_after_transitions(attr_changes).each { |i| i.call(self) }
+              @@#{attr}_machine.fetch_after_transitions(attr_changes).each { |block| instance_exec(self, *attr_changes, &block) }
             end
           end
         RUBY

--- a/spec/enum_machine/active_record_machine_spec.rb
+++ b/spec/enum_machine/active_record_machine_spec.rb
@@ -121,4 +121,28 @@ RSpec.describe 'DriverActiveRecord', :ar do
       }.to raise_error(EnumMachine::Error, 'transition nil => "activated" not defined in enum_machine')
     end
   end
+
+  it 'checks callbacks context' do
+    Semaphore =
+      Class.new(TestModel) do
+        enum_machine :color, %w[green orange red] do
+          transitions(
+            [nil, 'red'] => 'green',
+            'green'      => 'orange',
+            'orange'     => 'red',
+            )
+          after_transition any => 'green' do
+            self.message = 'Go!'
+          end
+          before_transition any => any do |item, from, to|
+            item.message = "#{from} => #{to}"
+          end
+        end
+      end
+
+    semaphore = Semaphore.new
+
+    expect { semaphore.update!(color: 'green') }.to change(semaphore, :message).to 'Go!'
+    expect { semaphore.update!(color: 'orange') }.to change(semaphore, :message).to 'green => orange'
+  end
 end

--- a/spec/enum_machine/active_record_machine_spec.rb
+++ b/spec/enum_machine/active_record_machine_spec.rb
@@ -123,14 +123,14 @@ RSpec.describe 'DriverActiveRecord', :ar do
   end
 
   it 'checks callbacks context' do
-    Semaphore =
+    semaphore =
       Class.new(TestModel) do
         enum_machine :color, %w[green orange red] do
           transitions(
             [nil, 'red'] => 'green',
             'green'      => 'orange',
             'orange'     => 'red',
-            )
+          )
           after_transition any => 'green' do
             self.message = 'Go!'
           end
@@ -140,9 +140,9 @@ RSpec.describe 'DriverActiveRecord', :ar do
         end
       end
 
-    semaphore = Semaphore.new
+    m = semaphore.new
 
-    expect { semaphore.update!(color: 'green') }.to change(semaphore, :message).to 'Go!'
-    expect { semaphore.update!(color: 'orange') }.to change(semaphore, :message).to 'green => orange'
+    expect { m.update!(color: 'green') }.to change(m, :message).to 'Go!'
+    expect { m.update!(color: 'orange') }.to change(m, :message).to 'green => orange'
   end
 end


### PR DESCRIPTION
Необходимо для DI, сейчас контекст в коллбеке - инстанс enum_machine, а метод `send_purchase` добавляется на уровне `Purchase`. Но и в принципе так получается чуть меньше кода

```ruby
class Purchase
  include ::Deps['supplier_delivery/services/send_purchase']
  
  enum_machine :state, %w[...] do
    after_transition 'created' => 'billed' do
      send_purchase.call(purchase: self)
    end
  end
end
```
