### PR TITLE
fix(DriverActiveRecord): getting enum values not listed in .enum_machine

### DIFF
--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -37,6 +37,7 @@ module EnumMachine
 
       enum_value_klass = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine)
       enum_value_klass.extend(AttributePersistenceMethods[attr, enum_values])
+      klass.class_variable_set("@@#{attr}_enum_value_klass", enum_value_klass)
 
       enum_value_klass_mapping =
         enum_values.to_h do |enum_value|
@@ -53,7 +54,8 @@ module EnumMachine
         #   return unless enum_value
         #
         #   unless @state_enum == enum_value
-        #     @state_enum = @@state_attribute_mapping.fetch(enum_value).dup
+        #     @state_enum = @@state_attribute_mapping[enum_value].dup
+        #     @state_enum ||= @@state_enum_value_klass.new(enum_value)
         #     @state_enum.parent = self
         #   end
         #
@@ -65,7 +67,8 @@ module EnumMachine
           return unless enum_value
 
           unless @#{attr}_enum == enum_value
-            @#{attr}_enum = @@#{attr}_attribute_mapping.fetch(enum_value).dup
+            @#{attr}_enum = @@#{attr}_attribute_mapping[enum_value].dup
+            @#{attr}_enum ||= @@#{attr}_enum_value_klass.new(enum_value)
             @#{attr}_enum.parent = self
           end
 

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -38,14 +38,8 @@ module EnumMachine
       enum_value_klass = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine)
       enum_value_klass.extend(AttributePersistenceMethods[attr, enum_values])
 
-      enum_value_klass_mapping =
-        enum_values.to_h do |enum_value|
-          [
-            enum_value,
-            enum_value_klass.new(enum_value),
-          ]
-        end
-      enum_value_klass_mapping.default_proc = proc { |hash, key| hash[key] = enum_value_klass.new(key) }
+      # Hash.new with default_proc for working with custom values not defined in enum list
+      enum_value_klass_mapping = Hash.new { |hash, key| hash[key] = enum_value_klass.new(key) }
       klass.class_variable_set("@@#{attr}_attribute_mapping", enum_value_klass_mapping)
 
       klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1

--- a/spec/enum_machine/active_record_enum_spec.rb
+++ b/spec/enum_machine/active_record_enum_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe 'DriverActiveRecord', :ar do
     expect(m.color).to be_blue
   end
 
-  it 'returns value if it is not in enum values list' do
+  it 'works with custom value, not defined in enum list' do
     m = model.new(color: 'wrong')
 
     expect(m.color).to eq('wrong')
+    expect(m.color.red?).to eq(false)
     expect { m.color.wrong? }.to raise_error(NoMethodError)
   end
 

--- a/spec/enum_machine/active_record_enum_spec.rb
+++ b/spec/enum_machine/active_record_enum_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe 'DriverActiveRecord', :ar do
     expect(m.color).to be_blue
   end
 
+  it 'returns value if it is not in enum values list' do
+    m = model.new(color: 'wrong')
+
+    expect(m.color).to eq('wrong')
+    expect { m.color.wrong? }.to raise_error(NoMethodError)
+  end
+
   it 'pretty print inspect' do
     m = model.new(state: 'choice')
     expect(m.state.inspect).to match(/EnumMachine:BuildAttribute.+value=choice parent=/)


### PR DESCRIPTION
Сейчас в ситуации, когда в enum атрибуте модели установлено значение, которе не перечислено в enum_machine (например пришло из БД), мы не можем его получить через атрибут модели, вылетает KeyError. Исправил такое поведение:

```ruby
class TestModel < ApplicationRecord
  enum_machine :state, %w[foo bar]
end

record = TestModel.new(state: wrong)
# Было:
record.state # => KeyError: key not found: "wrong"
# Стало:
record.state # => #<EnumMachine:BuildAttribute value=wrong parent=#<TestModel mode: "discount">>
```

Если так ок, то думаю аналогично можно поменять и `DriverSimpleClass`