### PR TITLE
fix simple driver for AR-object

### DIFF
--- a/spec/enum_machine/active_record_machine_spec.rb
+++ b/spec/enum_machine/active_record_machine_spec.rb
@@ -5,7 +5,8 @@ require 'enum_machine/rspec'
 RSpec.describe 'DriverActiveRecord', :ar do
   model =
     Class.new(TestModel) do
-      enum_machine :color, %w[red green blue]
+      include EnumMachine[color: { enum: %w[red green blue] }]
+
       enum_machine :state, %w[created approved cancelled activated cancelled] do
         transitions(
           nil                    => 'created',


### PR DESCRIPTION
Если EnumMachine заинклудить модулем в AR-объект, происходит ошибка

```
An error occurred while loading ./spec/enum_machine/active_record_machine_spec.rb.
Failure/Error: klass.alias_method read_method, attr

NameError:
  undefined method `color' for class `#<Class:0x00005572dc69a4c0> (call '#<Class:0x00005572dc69a4c0>.connection' to establish a connection)'
# ./lib/enum_machine/driver_simple_class.rb:35:in `alias_method'
```