### PR TITLE
Decorators refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
 Rails/ApplicationRecord:
   Enabled: false
 
+Rails/Output:
+  Enabled: false
+
 Metrics/ParameterLists:
   CountKeywordArgs: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    enum_machine (1.0.0)
+    enum_machine (2.0.0)
       activemodel
       activerecord
       activesupport
@@ -138,7 +138,7 @@ GEM
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
-    timeout (0.4.1)
+    timeout (0.4.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.2)

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ class Product
   attr_accessor :color
 
   include EnumMachine[color: {
-    enum:      %w[red green],
-    decorator: ColorDecorator
+    enum:            %w[red green],
+    value_decorator: ColorDecorator
   }]
 end
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class Product
 
   include EnumMachine[color: { enum: %w[red green] }]
   # or reuse from model
-  Product::COLOR.decorator_module
+  Product::COLOR.enum_decorator
 end
 
 Product::COLOR.values # => ["red", "green"]

--- a/lib/enum_machine.rb
+++ b/lib/enum_machine.rb
@@ -2,9 +2,9 @@
 
 require_relative "enum_machine/version"
 require_relative "enum_machine/driver_simple_class"
-require_relative "enum_machine/build_attribute"
+require_relative "enum_machine/build_value_class"
 require_relative "enum_machine/attribute_persistence_methods"
-require_relative "enum_machine/build_class"
+require_relative "enum_machine/build_enum_class"
 require_relative "enum_machine/machine"
 require "active_support"
 

--- a/lib/enum_machine/build_attribute.rb
+++ b/lib/enum_machine/build_attribute.rb
@@ -2,11 +2,11 @@
 
 module EnumMachine
   module BuildAttribute
-    def self.call(enum_values:, i18n_scope:, decorator:, machine: nil)
+    def self.call(enum_values:, i18n_scope:, value_decorator:, machine: nil)
       aliases = machine&.instance_variable_get(:@aliases) || {}
 
       Class.new(String) do
-        include(decorator) if decorator
+        include(value_decorator) if value_decorator
 
         define_method(:machine) { machine } if machine
 

--- a/lib/enum_machine/build_enum_class.rb
+++ b/lib/enum_machine/build_enum_class.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module EnumMachine
-  module BuildClass
+  module BuildEnumClass
     def self.call(enum_values:, i18n_scope:, value_class:, machine: nil)
       aliases = machine&.instance_variable_get(:@aliases) || {}
 

--- a/lib/enum_machine/build_value_class.rb
+++ b/lib/enum_machine/build_value_class.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module EnumMachine
-  module BuildAttribute
+  module BuildValueClass
     def self.call(enum_values:, i18n_scope:, value_decorator:, machine: nil)
       aliases = machine&.instance_variable_get(:@aliases) || {}
 

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -108,10 +108,6 @@ module EnumMachine
           end
         end
       enum_class.define_singleton_method(:enum_decorator) { enum_decorator }
-      enum_class.define_singleton_method(:decorator_module) do
-        puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
-        enum_decorator
-      end
 
       klass.include(enum_decorator)
 

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -2,7 +2,7 @@
 
 module EnumMachine
   module DriverActiveRecord
-    def enum_machine(attr, enum_values, i18n_scope: nil, decorator: nil, &block)
+    def enum_machine(attr, enum_values, i18n_scope: nil, value_decorator: nil, &block)
       klass = self
 
       i18n_scope ||= "#{klass.base_class.to_s.underscore}.#{attr}"
@@ -11,7 +11,7 @@ module EnumMachine
       machine = Machine.new(enum_values, klass, enum_const_name, attr)
       machine.instance_eval(&block) if block
 
-      value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, decorator: decorator)
+      value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_decorator: value_decorator)
       enum_klass = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_class: value_class)
 
       value_class.extend(AttributePersistenceMethods[attr, enum_values])

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -107,7 +107,11 @@ module EnumMachine
             decorating_klass.const_set enum_const_name, enum_klass
           end
         end
-      enum_klass.define_singleton_method(:decorator_module) { enum_decorator }
+      enum_klass.define_singleton_method(:enum_decorator) { enum_decorator }
+      enum_klass.define_singleton_method(:decorator_module) do
+        puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
+        enum_decorator
+      end
 
       klass.include(enum_decorator)
 

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -12,12 +12,12 @@ module EnumMachine
       machine.instance_eval(&block) if block
 
       value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_decorator: value_decorator)
-      enum_klass = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_class: value_class)
+      enum_class = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_class: value_class)
 
       value_class.extend(AttributePersistenceMethods[attr, enum_values])
 
       # default_proc for working with custom values not defined in enum list but may exists in db
-      enum_klass.value_attribute_mapping.default_proc =
+      enum_class.value_attribute_mapping.default_proc =
         proc do |hash, enum_value|
           hash[enum_value] = value_class.new(enum_value).freeze
         end
@@ -102,13 +102,13 @@ module EnumMachine
 
       enum_decorator =
         Module.new do
-          define_singleton_method(:included) do |decorating_klass|
-            decorating_klass.prepend define_methods
-            decorating_klass.const_set enum_const_name, enum_klass
+          define_singleton_method(:included) do |decorating_class|
+            decorating_class.prepend define_methods
+            decorating_class.const_set enum_const_name, enum_class
           end
         end
-      enum_klass.define_singleton_method(:enum_decorator) { enum_decorator }
-      enum_klass.define_singleton_method(:decorator_module) do
+      enum_class.define_singleton_method(:enum_decorator) { enum_decorator }
+      enum_class.define_singleton_method(:decorator_module) do
         puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
         enum_decorator
       end

--- a/lib/enum_machine/driver_active_record.rb
+++ b/lib/enum_machine/driver_active_record.rb
@@ -11,8 +11,8 @@ module EnumMachine
       machine = Machine.new(enum_values, klass, enum_const_name, attr)
       machine.instance_eval(&block) if block
 
-      value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_decorator: value_decorator)
-      enum_class = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_class: value_class)
+      value_class = BuildValueClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_decorator: value_decorator)
+      enum_class = BuildEnumClass.call(enum_values: enum_values, i18n_scope: i18n_scope, machine: machine, value_class: value_class)
 
       value_class.extend(AttributePersistenceMethods[attr, enum_values])
 

--- a/lib/enum_machine/driver_simple_class.rb
+++ b/lib/enum_machine/driver_simple_class.rb
@@ -11,15 +11,15 @@ module EnumMachine
       Module.new do
         define_singleton_method(:included) do |klass|
           args.each do |attr, params|
-            enum_values  = params.fetch(:enum)
-            i18n_scope   = params.fetch(:i18n_scope, nil)
-            decorator    = params.fetch(:decorator, nil)
+            enum_values     = params.fetch(:enum)
+            i18n_scope      = params.fetch(:i18n_scope, nil)
+            value_decorator = params.fetch(:value_decorator, nil)
 
             if defined?(ActiveRecord) && klass <= ActiveRecord::Base
               klass.enum_machine(attr, enum_values, i18n_scope: i18n_scope)
             else
               enum_const_name = attr.to_s.upcase
-              value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, decorator: decorator)
+              value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, value_decorator: value_decorator)
               enum_klass = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_class: value_class)
 
               define_methods =

--- a/lib/enum_machine/driver_simple_class.rb
+++ b/lib/enum_machine/driver_simple_class.rb
@@ -19,8 +19,8 @@ module EnumMachine
               klass.enum_machine(attr, enum_values, i18n_scope: i18n_scope)
             else
               enum_const_name = attr.to_s.upcase
-              value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, value_decorator: value_decorator)
-              enum_class = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_class: value_class)
+              value_class = BuildValueClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_decorator: value_decorator)
+              enum_class = BuildEnumClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_class: value_class)
 
               define_methods =
                 Module.new do

--- a/lib/enum_machine/driver_simple_class.rb
+++ b/lib/enum_machine/driver_simple_class.rb
@@ -40,10 +40,6 @@ module EnumMachine
                   end
                 end
               enum_class.define_singleton_method(:enum_decorator) { enum_decorator }
-              enum_class.define_singleton_method(:decorator_module) do
-                puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
-                enum_decorator
-              end
 
               klass.include(enum_decorator)
               enum_decorator

--- a/lib/enum_machine/driver_simple_class.rb
+++ b/lib/enum_machine/driver_simple_class.rb
@@ -39,7 +39,11 @@ module EnumMachine
                     decorating_klass.const_set enum_const_name, enum_klass
                   end
                 end
-              enum_klass.define_singleton_method(:decorator_module) { enum_decorator }
+              enum_klass.define_singleton_method(:enum_decorator) { enum_decorator }
+              enum_klass.define_singleton_method(:decorator_module) do
+                puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
+                enum_decorator
+              end
 
               klass.include(enum_decorator)
               enum_decorator

--- a/lib/enum_machine/driver_simple_class.rb
+++ b/lib/enum_machine/driver_simple_class.rb
@@ -20,7 +20,7 @@ module EnumMachine
             else
               enum_const_name = attr.to_s.upcase
               value_class = BuildAttribute.call(enum_values: enum_values, i18n_scope: i18n_scope, value_decorator: value_decorator)
-              enum_klass = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_class: value_class)
+              enum_class = BuildClass.call(enum_values: enum_values, i18n_scope: i18n_scope, value_class: value_class)
 
               define_methods =
                 Module.new do
@@ -28,19 +28,19 @@ module EnumMachine
                     enum_value = super()
                     return unless enum_value
 
-                    enum_klass.value_attribute_mapping.fetch(enum_value)
+                    enum_class.value_attribute_mapping.fetch(enum_value)
                   end
                 end
 
               enum_decorator =
                 Module.new do
-                  define_singleton_method(:included) do |decorating_klass|
-                    decorating_klass.prepend define_methods
-                    decorating_klass.const_set enum_const_name, enum_klass
+                  define_singleton_method(:included) do |decorating_class|
+                    decorating_class.prepend define_methods
+                    decorating_class.const_set enum_const_name, enum_class
                   end
                 end
-              enum_klass.define_singleton_method(:enum_decorator) { enum_decorator }
-              enum_klass.define_singleton_method(:decorator_module) do
+              enum_class.define_singleton_method(:enum_decorator) { enum_decorator }
+              enum_class.define_singleton_method(:decorator_module) do
                 puts "#decorator_module is deprecated and will be removed in next major release, use #enum_decorator instead"
                 enum_decorator
               end

--- a/lib/enum_machine/version.rb
+++ b/lib/enum_machine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EnumMachine
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/spec/enum_machine/active_record_enum_spec.rb
+++ b/spec/enum_machine/active_record_enum_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "DriverActiveRecord", :ar do
   end
 
   context "when with decorator" do
-    let(:decorator_module) do
+    let(:enum_decorator) do
       Module.new do
         def am_i_choice?
           self == "choice"
@@ -88,7 +88,7 @@ RSpec.describe "DriverActiveRecord", :ar do
     end
 
     let(:model_with_decorator) do
-      decorator = decorator_module
+      decorator = enum_decorator
       Class.new(TestModel) do
         enum_machine :state, %w[choice in_delivery], decorator: decorator
       end
@@ -127,8 +127,8 @@ RSpec.describe "DriverActiveRecord", :ar do
 
     decorated_klass =
       Class.new do
-        include decorating_model::STATE.decorator_module
-        include decorating_model::COLOR.decorator_module
+        include decorating_model::STATE.enum_decorator
+        include decorating_model::COLOR.enum_decorator
         attr_accessor :state, :color
       end
 

--- a/spec/enum_machine/active_record_enum_spec.rb
+++ b/spec/enum_machine/active_record_enum_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe "DriverActiveRecord", :ar do
     end
   end
 
-  context "when with decorator" do
-    let(:enum_decorator) do
+  context "when with value_decorator" do
+    let(:decorator) do
       Module.new do
         def am_i_choice?
           self == "choice"
@@ -88,9 +88,9 @@ RSpec.describe "DriverActiveRecord", :ar do
     end
 
     let(:model_with_decorator) do
-      decorator = enum_decorator
+      value_decorator = decorator
       Class.new(TestModel) do
-        enum_machine :state, %w[choice in_delivery], decorator: decorator
+        enum_machine :state, %w[choice in_delivery], value_decorator: value_decorator
       end
     end
 

--- a/spec/enum_machine/driver_simple_class_spec.rb
+++ b/spec/enum_machine/driver_simple_class_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "DriverSimpleClass" do
     it "keeps decorating on #enum_decorator" do
       decorated_klass =
         Class.new do
-          include TestClass::STATE.enum_decorator
+          include TestClassWithDecorator::STATE.enum_decorator
           attr_accessor :state
         end
 

--- a/spec/enum_machine/driver_simple_class_spec.rb
+++ b/spec/enum_machine/driver_simple_class_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe "DriverSimpleClass" do
       expect(TestClass::STATE["wrong"]).to be_nil
     end
 
-    it "#decorator_module" do
+    it "#enum_decorator" do
       decorated_klass =
         Class.new do
-          include TestClass::STATE.decorator_module
+          include TestClass::STATE.enum_decorator
           attr_accessor :state
         end
 

--- a/spec/enum_machine/driver_simple_class_spec.rb
+++ b/spec/enum_machine/driver_simple_class_spec.rb
@@ -10,7 +10,7 @@ class TestClass
   include EnumMachine[state: { enum: %w[choice in_delivery] }]
 end
 
-module Decorator
+module ValueDecorator
   def am_i_choice?
     self == "choice"
   end
@@ -23,7 +23,7 @@ class TestClassWithDecorator
     @state = state
   end
 
-  include EnumMachine[state: { enum: %w[choice in_delivery], decorator: Decorator }]
+  include EnumMachine[state: { enum: %w[choice in_delivery], value_decorator: ValueDecorator }]
 end
 
 RSpec.describe "DriverSimpleClass" do

--- a/spec/enum_machine/driver_simple_class_spec.rb
+++ b/spec/enum_machine/driver_simple_class_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "DriverSimpleClass" do
     it "#enum_decorator" do
       decorated_klass =
         Class.new do
-          include TestClass::STATE.enum_decorator
+          include TestClassWithDecorator::STATE.enum_decorator
           attr_accessor :state
         end
 
@@ -126,6 +126,19 @@ RSpec.describe "DriverSimpleClass" do
       m = TestClassWithDecorator.new("choice")
       unserialized_m = Marshal.load(Marshal.dump(m)) # rubocop:disable Gp/UnsafeYamlMarshal
       expect(unserialized_m.state.am_i_choice?).to be(true)
+    end
+
+    it "keeps decorating on #enum_decorator" do
+      decorated_klass =
+        Class.new do
+          include TestClass::STATE.enum_decorator
+          attr_accessor :state
+        end
+
+      decorated_item = decorated_klass.new
+      decorated_item.state = "choice"
+
+      expect(decorated_item.state.am_i_choice?).to be(true)
     end
   end
 


### PR DESCRIPTION
renamed:

- `decorator` option => `value_decorator`
- `#decorator_module` method => `#enum_decorator` with deprecation warning
- class builders names (private api)

Decorating AR models with `#enum_decorator` from a plain class works fine already